### PR TITLE
Add update-grayskull and automerge=true

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,3 +5,6 @@ github:
 conda_build:
   error_overlinking: true
 conda_forge_output_validation: true
+bot:
+  automerge: true
+  inspection: update-grayskull


### PR DESCRIPTION
This PR enables Grayskull to automatically update the run requirements of your feedstock when a new package version is found.

This feature has been available for v1 (rattler-build) recipes since [regro/cf-scripts#4575](https://github.com/regro/cf-scripts/pull/4575).

It configures `conda-forge.yml` as follows:
```yaml
bot:
  automerge: true
  inspection: update-grayskull
```
If the file was missing, it has been created.